### PR TITLE
refactor：通过信号量实现全局并发控制

### DIFF
--- a/crawler/config.py.example
+++ b/crawler/config.py.example
@@ -5,22 +5,30 @@ from pathlib import Path
 DB_PATH = Path(__file__).parent.parent / "bili_videos.db"
 INIT_SQL_PATH: str = "init.sql" 
 
-DELAY_SECONDS = lambda: 1.5 + random() * 2
-MAX_CONCURRENCY = 5  # 最大并发
-MAX_BATCH_SIZE = 5  # 视频标签获取最大批量数
 
+# --- 全局行为控制 ---
+# 全局最大并发数：所有网络请求、数据库操作都受此限制(fetch_video_list除外)
+MAX_CONCURRENCY = 5
+# 视频块大小
+CHUNK_SIZE = 50  # 每次处理的视频块大小，50是一个安全且高效的选择
+
+
+# --- 延迟控制 ---
+# 单个API请求之间的随机延迟
+DELAY_SECONDS = lambda: uniform(0.1, 0.3)
+# 每个视频块处理完成后的固定延迟
+CHUNK_DELAY_SECONDS = lambda: 5 + random() * 5
+
+
+# --- 批量请求特定配置 ---
 BATCH_FETCH_CONFIG = {
-    'max_concurrent': 5,  # 最大并发数
-    'retry_times': 2,  # 最大重试次数
-    'retry_delay': 10  # 批次重试延迟
+    'retry_times': 2,  # 针对失败请求的重试次数
+    'retry_delay': 10  # 重试时的等待时间（秒）
 }
 
-CHUNK_SIZE = 50  # 每次处理的视频块大小，50是一个安全且高效的选择
-CHUNK_DELAY_SECONDS = lambda: 5 + random() * 5  # 每个块处理完后的延迟，5到10秒的随机延迟
 
+# --- 请求头信息 ---
 SESSDATA: str = """"""
-
-
 HEADERS = {
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 Edg/139.0.0.0',
     'Cookie': f'SESSDATA={SESSDATA}',

--- a/crawler/main.py
+++ b/crawler/main.py
@@ -30,8 +30,8 @@ async def process_video_batch(videos: list[Video], session: aiohttp.ClientSessio
     
     # 并发获取标签和分P信息
     logger.info(f"开始批量获取 {len(videos)} 个视频(1个块)的信息")
-    tags_task = fetch_tags(videos, session)
-    parts_task = fetch_parts(videos, session)
+    tags_task = fetch_tags(videos, session, semaphore)
+    parts_task = fetch_parts(videos, session, semaphore)
     tags_dict, parts_dict = await asyncio.gather(tags_task, parts_task)
     logger.info(f"成功获取 {len(tags_dict)} 个视频的标签和 {len(parts_dict)} 个视频的分P信息")
 


### PR DESCRIPTION
引入全局信号量机制管理并发网络请求和数据库操作，以缓解412风控问题

关键变更：
- **集中化并发控制**：在`config.py`新增`MAX_CONCURRENCY`配置项作为唯一并发控制基准
- **信号量传递机制**：主程序`main.py`创建单一`asyncio.Semaphore`实例并传递至处理链路（`process_video_batch` → `fetcher`函数）
- **重构抓取函数**：更新`fetcher.py`中的`fetch_parts`和`fetch_tags`函数，使其接收并共享信号量，确保所有详情请求遵循统一并发限制

此项变更将请求模式从无序突发转变为稳定可控的数据流，显著提升爬虫稳定性并降低触发速率限制的风险。

## Sourcery 总结

通过集中管理并发限制并在整个获取（fetch）工作流中统一传递单个 `asyncio.Semaphore` 实例，为网络和数据库操作引入基于全局信号量的并发控制。

增强功能：
- 将 `config.py` 中的 `MAX_CONCURRENCY` 设置集中化，作为并发限制的单一来源
- 重构 `fetch_batch_data` 以接受和使用共享信号量，而不是创建单独的信号量
- 将共享的 `asyncio.Semaphore` 从 `main` 通过 `process_video_batch` 传播到 `fetch_parts` 和 `fetch_tags`
- 更新内联测试和主入口点，以实例化并传递共享信号量

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce global semaphore-based concurrency control for network and database operations by centralizing the concurrency limit and uniformly passing a single asyncio.Semaphore instance through the fetch workflow

Enhancements:
- Centralize MAX_CONCURRENCY setting in config.py as the single source of concurrency limits
- Refactor fetch_batch_data to accept and use a shared semaphore instead of creating individual semaphores
- Propagate the shared asyncio.Semaphore from main through process_video_batch to fetch_parts and fetch_tags
- Update inline tests and main entrypoint to instantiate and pass the shared semaphore

</details>