### PR TITLE
chore(ci): 新增自动标记新PR的工作流

### DIFF
--- a/.github/workflows/label_new_pr.yml
+++ b/.github/workflows/label_new_pr.yml
@@ -1,16 +1,20 @@
 name: 'Assign Triage Label to New PRs'
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 jobs:
-  add-label:
-    name: 'Add "Status: Triage" Label'
+  labeler:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - name: Add Triage Label
-        uses: daneden/add-pr-label@v4
+      - name: 'Add "Status: Triage" label'
+        uses: actions/github-script@v7
         with:
-          label: 'Status: Triage'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['Status: Triage']
+            });


### PR DESCRIPTION
本工作流会自动为所有新开启的拉取请求添加"Status: Triage"标签。

该流程通过确保每个新PR具备清晰初始状态，帮助标准化PR管理流程，便于维护者追踪和审核新提交的贡献。

## Sourcery 总结

CI:
- 添加工作流，使用 daneden/add-pr-lebal 自动为新 PR 标记 "Status: Triage"

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

CI：
- 引入 .github/workflows/label_new_pr.yml，使用 daneden/add-pr-label 为新的 PRs 应用 'Status: Triage' 标签

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Introduce .github/workflows/label_new_pr.yml to apply 'Status: Triage' label to new PRs using daneden/add-pr-label

</details>

</details>