### PR TITLE
feat(api): 为视频API添加Pydantic模型

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List
 
 
@@ -21,7 +21,7 @@ class Video(BaseModel):
     pic: str
     created: int
     touhou_status: int
-    parts: List[VideoPart]= []
-    tags: List[str] = []
+    parts: List[VideoPart]= Field(default_factory=list)
+    tags: List[str] = Field(default_factory=list)
     class Config:
         from_attributes = True


### PR DESCRIPTION
- 在`api/models.py`中定义`Video`和`VideoPart`的Pydantic模型
- 这些模型将作为`/api/v1/videos`端点的数据契约
- 使模型结构与`shared/video.py`中的内部类保持一致

## Sourcery 总结

提供 Pydantic 模型 `Video` 和 `VideoPart` 作为 `/api/v1/videos` 端点的数据契约，镜像内部共享类。

新功能：
- 添加 `VideoPart` Pydantic 模型，用于视频片段数据
- 添加 `Video` Pydantic 模型，用于包含嵌套片段和标签的视频元数据

改进：
- 在两个模型上通过 `Config.from_attributes` 启用基于属性的数据填充

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

引入 Pydantic 模型用于视频 API 响应，以定义与内部共享类保持一致的数据契约。

新功能：
- 添加 VideoPart Pydantic 模型，代表单个视频片段数据
- 添加 Video Pydantic 模型，封装嵌套的视频片段和标签

改进：
- 在这两个模型中，通过 `Config.from_attributes` 启用基于属性的填充

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce Pydantic models for video API responses to define a data contract aligned with internal shared classes.

New Features:
- Add VideoPart Pydantic model representing individual video segment data
- Add Video Pydantic model encapsulating nested video parts and tags

Enhancements:
- Enable attribute-based population via Config.from_attributes in both models

</details>

</details>