### PR TITLE
refactor: 重构v1版本视频API端点

### DIFF
--- a/app/api/v1/videos.py
+++ b/app/api/v1/videos.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Depends, HTTPException
+from typing import List
+import sqlite3
+
+from ...models import Video
+from ...database import get_db, get_all_videos, get_video_parts
+
+
+router = APIRouter()
+@router.get("", response_model=List[Video])
+def read_videos(db: sqlite3.Connection = Depends(get_db)):
+    """提供视频列表的 JSON 数据给前端"""
+    try:
+        videos = get_all_videos(db)
+        
+        response_videos = []
+        for video_row in videos:
+            video_data = dict(video_row)
+
+            video_parts = get_video_parts(db, video_data['aid'])
+
+            video_data['parts'] = [dict(part) for part in video_parts]
+            tags_str = video_data.get('tags')
+            video_data['tags'] = [tag.strip() for tag in tags_str.split(',')] if tags_str else []
+
+            response_videos.append(video_data)
+        
+        return response_videos
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="An error occurred while fetching videos.") from e

--- a/app/main.py
+++ b/app/main.py
@@ -1,18 +1,19 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from typing import List
 
-from .models import Video
-from shared.database import Database
+from .api.v1 import videos
 
-
-app = FastAPI()
+app = FastAPI(
+    title="Touhou Memory Archive API",
+    description="API for accessing Touhou Memory video archive data.",
+    version="1.0.0",
+)
 
 origins = [
     "http://localhost",
-    "http://localhost:5173",  # Vite
-    "http://localhost:8080",  # Vue CLI
-    "http://localhost:3000"
+    "http://localhost:3000",
+    "http://localhost:5173",
+    "http://localhost:8080",
 ]
 
 app.add_middleware(
@@ -23,16 +24,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+app.include_router(videos.router, prefix="/api/v1/videos", tags=["videos"])
 
-@app.get("/api/v1/videos", response_model=List[Video])
-def read_videos():
-    """
-    提供视频列表的 JSON 数据给前端
-    """
-    try:
-        return Database.get_all_videos_for_api()
-    except Exception as e:
-        raise HTTPException(status_code=500, detail="An error occurred while fetching videos.") from e
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
将`main.py`中路由逻辑移至`/api/v1/videos.py`以实现应用路由模块化

## Sourcery 总结

通过将 v1 视频 API 的路由和处理逻辑移至专门的路由器模块，实现其模块化，并使用元数据增强 FastAPI 应用程序。

增强功能：
- 将 `/api/v1/videos` 端点从 `main.py` 提取到一个新的 `app/api/v1/videos.py` 路由器中
- 在 FastAPI 应用程序实例化时添加应用程序元数据（标题、描述、版本）
- 在 `main.py` 中注册视频路由器，并附带适当的前缀和标签

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modularize the v1 videos API by moving its route and handler logic into a dedicated router module and enhance the FastAPI application with metadata.

Enhancements:
- Extract the /api/v1/videos endpoint from main.py into a new app/api/v1/videos.py router
- Add application metadata (title, description, version) to the FastAPI app instantiation
- Register the videos router in main.py with the appropriate prefix and tags

</details>