### PR TITLE
fix(crawler): 修复 bgm 标签未被过滤的问题

### DIFF
--- a/backend/src/crawler/core/video_fetcher.py
+++ b/backend/src/crawler/core/video_fetcher.py
@@ -109,6 +109,12 @@ class BiliClient:
 
     async def get_video_tags(self, bvid: str) -> list[VideoTag]:
         data = await self.api.get_video_tags(bvid)
-        if isinstance(data, list):
-            return [VideoTag.model_validate(t) for t in data]
-        return []
+        if not isinstance(data, list):
+            return []
+        tags = []
+        for t in data:
+            try:
+                tags.append(VideoTag.model_validate(t))
+            except Exception:
+                logger.warning(f"跳过格式异常的标签: {t}")
+        return tags

--- a/backend/src/crawler/core/video_fetcher.py
+++ b/backend/src/crawler/core/video_fetcher.py
@@ -115,6 +115,6 @@ class BiliClient:
         for t in data:
             try:
                 tags.append(VideoTag.model_validate(t))
-            except Exception:
+            except ValueError:
                 logger.warning(f"跳过格式异常的标签: {t}")
         return tags

--- a/backend/src/crawler/core/video_fetcher.py
+++ b/backend/src/crawler/core/video_fetcher.py
@@ -3,7 +3,7 @@ import logging
 from typing import AsyncGenerator
 
 from crawler.api.bili_api import BiliAPI
-from crawler.api.models import SpaceVideoItem, SeasonArchiveItem, Page
+from crawler.api.models import SpaceVideoItem, SeasonArchiveItem, Page, VideoTag
 from crawler.config import PRODUCER_PAGE_DELAY_SECONDS
 from crawler.converters import space_item_to_video, season_item_to_video, page_to_part
 from shared.schemas import VideoSchema, VideoPartSchema
@@ -107,8 +107,8 @@ class BiliClient:
             return [page_to_part(Page.model_validate(p)) for p in data]
         return []
 
-    async def get_video_tags(self, bvid: str) -> list[str]:
+    async def get_video_tags(self, bvid: str) -> list[VideoTag]:
         data = await self.api.get_video_tags(bvid)
         if isinstance(data, list):
-            return [t.get('tag_name') for t in data if 'tag_name' in t]
+            return [VideoTag.model_validate(t) for t in data]
         return []

--- a/backend/src/crawler/core/video_processor.py
+++ b/backend/src/crawler/core/video_processor.py
@@ -1,8 +1,7 @@
-import re
 import logging
 import asyncio
 
-from crawler.api.models import Page
+from crawler.api.models import Page, VideoTag
 from crawler.converters import pages_to_parts
 from crawler.core.database import save_video
 from crawler.core.video_fetcher import BiliClient
@@ -16,7 +15,6 @@ class VideoService:
     """封装所有视频处理相关的业务逻辑"""
     def __init__(self, client: BiliClient):
         self.client = client
-        self.tag_pattern = re.compile(r'^\$发现《.+?》\^$')
         self.touhou_keywords = {
             "东方Project", "东方project", "东方PROJECT",
             "東方Project", "東方project", "東方PROJECT",
@@ -37,7 +35,7 @@ class VideoService:
 
             results = await asyncio.gather(tags_task, info_task, return_exceptions=True)
 
-            video_tags_result = []
+            video_tags_result: list[VideoTag] = []
             if not isinstance(results[0], Exception):
                 video_tags_result = results[0]
             else:
@@ -53,12 +51,12 @@ class VideoService:
                         pages = [Page.model_validate(p) for p in view_info['pages']]
                         video.parts = pages_to_parts(pages)
                     except Exception as e:
-                         logger.warning(f"解析视频 {video.bvid} 分P模型失败: {e}")
-                         video.parts = []
+                        logger.warning(f"解析视频 {video.bvid} 分P模型失败: {e}")
+                        video.parts = []
             else:
                 logger.warning(f"获取视频 {video.bvid} 的分P信息失败: {results[1]}")
 
-            video.tags = [tag for tag in video_tags_result if not self.tag_pattern.match(tag)]
+            video.tags = [t.tag_name for t in video_tags_result if t.tag_type != "bgm"]
             video.touhou_status = self._is_touhou(video.tags)
 
             save_video(video)


### PR DESCRIPTION
- get_video_tags 改为返回 list[VideoTag]，保留 tag_type 信息
- video_processor 用 tag_type != "bgm" 过滤，替代无效的正则匹配
- 移除未使用的 re 导入和 tag_pattern

## Summary by Sourcery

确保爬虫在保存视频元数据时保留标签类型信息，并正确排除 BGM 标签。

Bug Fixes:
- 使用 `tag_type` 字段从保存的视频标签中排除 BGM 标签，而不是依赖脆弱的基于正则表达式的过滤。

Enhancements:
- 将视频标签获取流程修改为返回带有类型信息、已验证的 `VideoTag` 对象，以便下游处理使用。
- 从视频处理工作流中移除已废弃的基于正则表达式的标签过滤逻辑和未使用的导入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure crawler preserves tag type information and correctly excludes BGM tags when saving video metadata.

Bug Fixes:
- Use the tag_type field to exclude BGM tags from saved video tags instead of relying on fragile regex-based filtering.

Enhancements:
- Change video tag fetching to return validated VideoTag objects with type information for downstream processing.
- Remove obsolete regex-based tag filtering logic and unused imports from the video processing workflow.

</details>

Bug Fixes（错误修复）:
- 使用 `tag_type` 来确保在保存视频标签时排除 BGM 类型的标签，而不是依赖脆弱的正则表达式匹配。

Enhancements（功能增强）:
- 更改视频标签的获取方式，使其返回带类型的 `VideoTag` 对象，以便下游处理可以使用 `tag_type` 信息。
- 清理未使用的、基于正则表达式的标签过滤逻辑及相关导入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保爬虫在保存视频元数据时保留标签类型信息，并正确排除 BGM 标签。

Bug Fixes:
- 使用 `tag_type` 字段从保存的视频标签中排除 BGM 标签，而不是依赖脆弱的基于正则表达式的过滤。

Enhancements:
- 将视频标签获取流程修改为返回带有类型信息、已验证的 `VideoTag` 对象，以便下游处理使用。
- 从视频处理工作流中移除已废弃的基于正则表达式的标签过滤逻辑和未使用的导入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure crawler preserves tag type information and correctly excludes BGM tags when saving video metadata.

Bug Fixes:
- Use the tag_type field to exclude BGM tags from saved video tags instead of relying on fragile regex-based filtering.

Enhancements:
- Change video tag fetching to return validated VideoTag objects with type information for downstream processing.
- Remove obsolete regex-based tag filtering logic and unused imports from the video processing workflow.

</details>

</details>