### PR TITLE
refactor(frontend): 适配后端新字段名

### DIFF
--- a/frontend/src/components/VideoRow.vue
+++ b/frontend/src/components/VideoRow.vue
@@ -25,7 +25,7 @@
         {{ highlightedUploader[0] }} <span v-if="highlightedUploader[1]" class="highlight"> {{ highlightedUploader[1] }} </span> {{ highlightedUploader[2] }}
       </span>
     </td>
-    <td>{{ video.created ? formatDate(video.created) : '未知日期' }}</td>
+    <td>{{ video.published_at ? formatDate(video.published_at) : '未知日期' }}</td>
     <td>
       <div :class="['status', `status-${video.touhou_status}`]">
         {{ getStatusText(video.touhou_status) }}
@@ -37,10 +37,9 @@
           无分P信息
         </div>
         <div v-else-if="video.parts.length === 1" class="part-item">
-          <div class="part-title">P1: {{ video.parts[0].part }}</div>
+          <div class="part-title">P1: {{ video.parts[0].title }}</div>
           <div class="part-meta">
             <span>时长: {{ formatTime(video.parts[0].duration) }}</span>
-            <span>创建: {{ formatDate(video.parts[0].ctime) }}</span>
           </div>
         </div>
         <div v-else class="parts-multi">
@@ -56,15 +55,14 @@
             </div>
           </div>
           <div class="parts-list fade-in" v-show="partsExpanded">
-            <div 
-              class="part-item" 
-              v-for="part in video.parts" 
-              :key="part.page"
+            <div
+              class="part-item"
+              v-for="part in video.parts"
+              :key="part.index"
             >
-              <div class="part-title">P{{ part.page }}: {{ part.part }}</div>
+              <div class="part-title">P{{ part.index }}: {{ part.title }}</div>
               <div class="part-meta">
                 <span>时长: {{ formatTime(part.duration) }}</span>
-                <span>创建: {{ formatDate(part.ctime) }}</span>
               </div>
             </div>
           </div>

--- a/frontend/src/components/VideoTooltip.vue
+++ b/frontend/src/components/VideoTooltip.vue
@@ -16,9 +16,9 @@
     >
       <div class="tooltip-content">
         <!-- 视频封面 -->
-        <div class="video-cover" v-if="video.pic && !imageError">
-          <img 
-            :src="video.pic" 
+        <div class="video-cover" v-if="video.cover_url && !imageError">
+          <img
+            :src="video.cover_url"
             :alt="video.title || '视频封面'"
             @error="handleImageError"
             referrerpolicy="no-referrer"
@@ -65,7 +65,7 @@ export default {
 
     // 检查是否有tooltip内容
     const hasTooltipContent = computed(() => {
-      return props.video.pic || props.video.description
+      return props.video.cover_url || props.video.description
     })
 
     // 检测应该显示在左侧还是右侧

--- a/frontend/src/components/VideoTooltip.vue
+++ b/frontend/src/components/VideoTooltip.vue
@@ -65,7 +65,7 @@ export default {
 
     // 检查是否有tooltip内容
     const hasTooltipContent = computed(() => {
-      return props.video.cover_url || props.video.description
+      return (!imageError.value && props.video.cover_url) || props.video.description
     })
 
     // 检测应该显示在左侧还是右侧


### PR DESCRIPTION
- video.pic → video.cover_url
- video.created → video.published_at
- video.parts[].part → video.parts[].title
- video.parts[].page → video.parts[].index
- 移除已删除的 ctime 字段引用

## Summary by Sourcery

将前端视频展示组件适配为使用后端新增的视频元数据和分集信息字段。

增强内容：
- 使用 `video.published_at` 替代已移除的 `created` 字段来显示视频日期。
- 更新视频分集渲染逻辑，使用 `title` 和 `index` 字段，并移除对已删除的 `ctime` 字段的引用。
- 将视频封面处理从已弃用的 `pic` 字段切换为新的 `cover_url` 字段，用于工具提示和相关检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adapt frontend video display components to new backend field names for video metadata and parts information.

Enhancements:
- Use video.published_at instead of the removed created field for displaying video dates.
- Update video parts rendering to use title and index fields and drop references to the removed ctime field.
- Switch video cover handling from the deprecated pic field to the new cover_url field in tooltips and related checks.

</details>