### PR TITLE
refactor(crawler): 拆分 BiliClient 职责，重命名为 VideoDiscovery

### DIFF
--- a/backend/src/crawler/core/video_fetcher.py
+++ b/backend/src/crawler/core/video_fetcher.py
@@ -3,10 +3,10 @@ import logging
 from typing import AsyncGenerator
 
 from crawler.api.bili_api import BiliAPI
-from crawler.api.models import SpaceVideoItem, SeasonArchiveItem, Page, VideoTag, VideoDetailData
+from crawler.api.models import SpaceVideoItem, SeasonArchiveItem
 from crawler.config import PRODUCER_PAGE_DELAY_SECONDS
-from crawler.converters import space_item_to_video, season_item_to_video, page_to_part
-from shared.schemas import VideoSchema, VideoPartSchema
+from crawler.converters import space_item_to_video, season_item_to_video
+from shared.schemas import VideoSchema
 
 from .delay_manager import DelayManager
 
@@ -14,7 +14,9 @@ from .delay_manager import DelayManager
 logger = logging.getLogger(__name__)
 
 
-class BiliClient:
+class VideoDiscovery:
+    """负责视频列表发现：用户空间分页、合集展开"""
+
     def __init__(self, api: BiliAPI):
         self.api = api
 
@@ -25,7 +27,10 @@ class BiliClient:
         page_size: int = 50
     ) -> AsyncGenerator[VideoSchema, None]:
         """
-        业务逻辑：循环分页获取用户所有视频，并自动展开合集
+        分页获取用户所有视频，自动展开合集。
+
+        每页之间有 PRODUCER_PAGE_DELAY_SECONDS 的延迟以规避风控。
+        第一页会更新 delay_manager 的视频总数，用于后续用户切换延迟计算。
         """
         page = 1
         processed_seasons = set()
@@ -71,7 +76,7 @@ class BiliClient:
             await asyncio.sleep(PRODUCER_PAGE_DELAY_SECONDS)
 
     async def _fetch_season(self, mid: int, season_id: int, delay_manager: DelayManager) -> AsyncGenerator[VideoSchema, None]:
-        """内部递归：获取合集"""
+        """获取合集内所有视频，分页处理"""
         page = 1
 
         while True:
@@ -97,26 +102,3 @@ class BiliClient:
             page += 1
             sleep_time = delay_manager.get_request_delay()
             await asyncio.sleep(sleep_time)
-
-    async def get_video_info(self, bvid: str) -> VideoDetailData:
-        """获取视频详情，失败时直接抛异常"""
-        raw = await self.api.get_video_detail(bvid)
-        return VideoDetailData.model_validate(raw)
-
-    async def get_video_parts(self, bvid: str) -> list[VideoPartSchema]:
-        data = await self.api.get_video_parts(bvid)
-        if isinstance(data, list):
-            return [page_to_part(Page.model_validate(p)) for p in data]
-        return []
-
-    async def get_video_tags(self, bvid: str) -> list[VideoTag]:
-        data = await self.api.get_video_tags(bvid)
-        if not isinstance(data, list):
-            return []
-        tags = []
-        for t in data:
-            try:
-                tags.append(VideoTag.model_validate(t))
-            except ValueError:
-                logger.warning(f"跳过格式异常的标签: {t}")
-        return tags

--- a/backend/src/crawler/core/video_processor.py
+++ b/backend/src/crawler/core/video_processor.py
@@ -1,10 +1,10 @@
 import logging
 import asyncio
 
-from crawler.api.models import VideoTag, VideoDetailData
+from crawler.api.bili_api import BiliAPI
+from crawler.api.models import VideoTag, VideoDetailData, Page
 from crawler.converters import pages_to_parts
 from crawler.core.database import save_video
-from crawler.core.video_fetcher import BiliClient
 from shared.schemas import VideoSchema
 
 
@@ -12,18 +12,39 @@ logger = logging.getLogger(__name__)
 
 
 class VideoService:
-    """封装所有视频处理相关的业务逻辑"""
-    def __init__(self, client: BiliClient):
-        self.client = client
-        self.touhou_keywords = {
-            "东方Project", "东方project", "东方PROJECT",
-            "東方Project", "東方project", "東方PROJECT",
-            "Touhou", "東方", "车万", "ZUN", "Zun", "zun"
-        }
+    """负责单个视频的处理：数据获取、业务逻辑、持久化"""
 
-    def _is_touhou(self, tags: list[str]) -> int:
-        """自动检测是否为东方视频 是:1 否:2"""
-        return 1 if any(keyword in tag for tag in tags for keyword in self.touhou_keywords) else 2
+    TOUHOU_KEYWORDS = {
+        "东方Project", "东方project", "东方PROJECT",
+        "東方Project", "東方project", "東方PROJECT",
+        "Touhou", "東方", "车万", "ZUN", "Zun", "zun"
+    }
+
+    def __init__(self, api: BiliAPI):
+        self.api = api
+
+    async def _fetch_video_detail(self, bvid: str) -> VideoDetailData:
+        """获取视频详情，失败时直接抛异常"""
+        raw = await self.api.get_video_detail(bvid)
+        return VideoDetailData.model_validate(raw)
+
+    async def _fetch_video_tags(self, bvid: str) -> list[VideoTag]:
+        """获取视频标签，逐条容错"""
+        data = await self.api.get_video_tags(bvid)
+        if not isinstance(data, list):
+            return []
+        tags = []
+        for t in data:
+            try:
+                tags.append(VideoTag.model_validate(t))
+            except ValueError:
+                logger.warning(f"跳过格式异常的标签: {t}")
+        return tags
+
+    @staticmethod
+    def _is_touhou(tags: list[str]) -> int:
+        """根据标签关键词判断是否为东方视频。是:1 否:2"""
+        return 1 if any(kw in tag for tag in tags for kw in VideoService.TOUHOU_KEYWORDS) else 2
 
     async def process_video(self, video: VideoSchema, semaphore: asyncio.Semaphore):
         """
@@ -40,11 +61,10 @@ class VideoService:
         5. 保存到数据库
         """
         try:
-            # semaphore 包住整个 gather，确保并发 I/O 真正受限
             async with semaphore:
                 tags, detail = await asyncio.gather(
-                    self.client.get_video_tags(video.bvid),
-                    self.client.get_video_info(video.bvid),
+                    self._fetch_video_tags(video.bvid),
+                    self._fetch_video_detail(video.bvid),
                 )
 
             # 用详情数据补全 video schema
@@ -62,7 +82,6 @@ class VideoService:
             video.share_count = detail.stat.share
             video.like_count = detail.stat.like
 
-            # 分P解析带防御性处理
             try:
                 video.parts = pages_to_parts(detail.pages)
             except Exception as e:

--- a/backend/src/crawler/main.py
+++ b/backend/src/crawler/main.py
@@ -7,7 +7,7 @@ from shared.database import init_db
 from shared.schemas import VideoSchema
 
 from crawler.api.bili_api import BiliAPI
-from crawler.core.video_fetcher import BiliClient
+from crawler.core.video_fetcher import VideoDiscovery
 from .config import MAX_CONCURRENCY, MAX_QUEUE_SIZE
 from crawler.core.database import get_all_user_mids
 from crawler.core.delay_manager import DelayManager
@@ -49,8 +49,8 @@ async def main():
 
     async with aiohttp.ClientSession() as http_session:
         bili_api = BiliAPI(http_session)
-        bili_client = BiliClient(bili_api)
-        video_service = VideoService(bili_client)
+        video_discovery = VideoDiscovery(bili_api)
+        video_service = VideoService(bili_api)
 
         for user in users:
             logger.info(f"--- 开始处理用户 {user} ---")
@@ -59,7 +59,7 @@ async def main():
 
             async def run_producer():
                 try:
-                    async for video in bili_client.get_user_all_videos(user, delay_manager):
+                    async for video in video_discovery.get_user_all_videos(user, delay_manager):
                         await video_queue.put(video)
                 except asyncio.CancelledError:
                     logger.info(f"用户 {user} 生产任务被取消")


### PR DESCRIPTION
- BiliClient → VideoDiscovery，只负责列表发现（分页、合集展开）
- get_video_info/get_video_tags 移入 VideoService 作为私有方法
- VideoService 改为持有 BiliAPI，不再依赖 BiliClient
- 删除未使用的 get_video_parts

## Summary by Sourcery

重构爬虫，将视频发现与单个视频的处理解耦，并简化对 Bilibili API 的依赖。

增强点：
- 将 `BiliClient` 重命名为 `VideoDiscovery`，并将其职责收窄为仅负责分页的用户视频列表和剧集（season）的展开。
- 将视频详情和标签获取逻辑迁移到 `VideoService`，直接使用 `BiliAPI`，并新增校验逻辑和对错误更具容错性的标签解析辅助函数。
- 更新爬虫主流程，对生产者（producers）使用 `VideoDiscovery`，同时 `VideoService` 现在只依赖 `BiliAPI`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the crawler to separate video discovery from per-video processing and simplify dependencies on the Bilibili API.

Enhancements:
- Rename BiliClient to VideoDiscovery and narrow its responsibility to paginated user video listing and season expansion.
- Move video detail and tag fetching into VideoService using BiliAPI directly, adding validation and error-tolerant tag parsing helpers.
- Update crawler main flow to use VideoDiscovery for producers while VideoService now depends only on BiliAPI.

</details>