### PR TITLE
feat(admin): 添加 touhou_status 编辑功能

### DIFF
--- a/backend/src/app/api/admin.py
+++ b/backend/src/app/api/admin.py
@@ -1,7 +1,7 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlmodel import Session, select
 
 from app.auth import require_role
@@ -15,10 +15,7 @@ router = APIRouter()
 
 
 class TouhouStatusUpdate(BaseModel):
-    touhou_status: int  # 0:未检测 1:自动东方 2:自动非东方 3:人工东方 4:人工非东方
-
-
-VALID_TOUHOU_STATUS = {0, 1, 2, 3, 4}
+    touhou_status: int = Field(ge=0, le=4)  # 0:未检测 1:自动东方 2:自动非东方 3:人工东方 4:人工非东方
 
 
 @router.patch("/videos/{bvid}/touhou-status")
@@ -28,11 +25,6 @@ def update_touhou_status(
     session: Session = Depends(get_session),
     current_admin: Admin = Depends(require_role(AdminRole.ADMIN)),
 ):
-    if body.touhou_status not in VALID_TOUHOU_STATUS:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"无效的 touhou_status 值，合法值: {sorted(VALID_TOUHOU_STATUS)}",
-        )
 
     video = session.exec(select(Video).where(Video.bvid == bvid)).first()
     if not video:

--- a/backend/src/app/api/admin.py
+++ b/backend/src/app/api/admin.py
@@ -1,0 +1,47 @@
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlmodel import Session, select
+
+from app.auth import require_role
+from domain.database import get_session
+from domain.models.admin import Admin, AdminRole
+from domain.models.video import Video
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class TouhouStatusUpdate(BaseModel):
+    touhou_status: int  # 0:未检测 1:自动东方 2:自动非东方 3:人工东方 4:人工非东方
+
+
+VALID_TOUHOU_STATUS = {0, 1, 2, 3, 4}
+
+
+@router.patch("/videos/{bvid}/touhou-status")
+def update_touhou_status(
+    bvid: str,
+    body: TouhouStatusUpdate,
+    session: Session = Depends(get_session),
+    current_admin: Admin = Depends(require_role(AdminRole.ADMIN)),
+):
+    if body.touhou_status not in VALID_TOUHOU_STATUS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"无效的 touhou_status 值，合法值: {sorted(VALID_TOUHOU_STATUS)}",
+        )
+
+    video = session.exec(select(Video).where(Video.bvid == bvid)).first()
+    if not video:
+        raise HTTPException(status_code=404, detail=f"视频 {bvid} 不存在")
+
+    video.touhou_status = body.touhou_status
+    session.add(video)
+    session.commit()
+    session.refresh(video)
+
+    logger.info(f"管理员 {current_admin.username} 将 {bvid} 的 touhou_status 改为 {body.touhou_status}")
+    return {"bvid": bvid, "touhou_status": video.touhou_status}

--- a/backend/src/app/api/admin.py
+++ b/backend/src/app/api/admin.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+# 前端对应定义在 frontend/src/utils/index.js 的 touhouStatusOptions，修改时需同步
 class TouhouStatus(IntEnum):
     UNKNOWN = 0
     AUTO_TOUHOU = 1

--- a/backend/src/app/api/admin.py
+++ b/backend/src/app/api/admin.py
@@ -1,7 +1,8 @@
 import logging
+from enum import IntEnum
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from sqlmodel import Session, select
 
 from app.auth import require_role
@@ -14,8 +15,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+class TouhouStatus(IntEnum):
+    UNKNOWN = 0
+    AUTO_TOUHOU = 1
+    AUTO_NON_TOUHOU = 2
+    MANUAL_TOUHOU = 3
+    MANUAL_NON_TOUHOU = 4
+
+
 class TouhouStatusUpdate(BaseModel):
-    touhou_status: int = Field(ge=0, le=4)  # 0:未检测 1:自动东方 2:自动非东方 3:人工东方 4:人工非东方
+    touhou_status: TouhouStatus
 
 
 @router.patch("/videos/{bvid}/touhou-status")

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -6,7 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
-from .api import videos, users, auth
+from .api import videos, users, auth, admin
 from .auth import hash_password
 from .config import SECRET_KEY  # noqa: F401 — 确保启动时校验
 from domain.database import engine, init_db
@@ -36,6 +36,7 @@ app.add_middleware(
 )
 
 app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
+app.include_router(admin.router, prefix="/api/v1/admin", tags=["admin"])
 app.include_router(videos.router, prefix="/api/v1/videos", tags=["videos"])
 app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
 

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -10,11 +10,11 @@ export const statusMap = {
 
 // 东方状态选项（管理后台用）
 export const touhouStatusOptions = [
-  { value: 0, label: "未检测",    cssClass: "status-unknown" },
-  { value: 1, label: "自动东方",  cssClass: "status-touhou" },
-  { value: 2, label: "自动非东方", cssClass: "status-non-touhou" },
-  { value: 3, label: "人工东方",  cssClass: "status-touhou" },
-  { value: 4, label: "人工非东方", cssClass: "status-non-touhou" },
+  { value: 0, label: "未检测" },
+  { value: 1, label: "自动东方" },
+  { value: 2, label: "自动非东方" },
+  { value: 3, label: "人工东方" },
+  { value: 4, label: "人工非东方" },
 ];
 
 // 格式化日期 (YYYY/MM/DD)

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -9,6 +9,7 @@ export const statusMap = {
 };
 
 // 东方状态选项（管理后台用）
+// 后端对应定义在 backend/src/app/api/admin.py 的 TouhouStatus IntEnum，修改时需同步
 export const touhouStatusOptions = [
   { value: 0, label: "未检测" },
   { value: 1, label: "自动东方" },

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -11,11 +11,11 @@ export const statusMap = {
 // 东方状态选项（管理后台用）
 // 后端对应定义在 backend/src/app/api/admin.py 的 TouhouStatus IntEnum，修改时需同步
 export const touhouStatusOptions = [
-  { value: 0, label: "未检测" },
-  { value: 1, label: "自动东方" },
-  { value: 2, label: "自动非东方" },
-  { value: 3, label: "人工东方" },
-  { value: 4, label: "人工非东方" },
+  { value: 0, label: "未检测",     touhou: null },
+  { value: 1, label: "自动东方",   touhou: true },
+  { value: 2, label: "自动非东方", touhou: false },
+  { value: 3, label: "人工东方",   touhou: true },
+  { value: 4, label: "人工非东方", touhou: false },
 ];
 
 // 格式化日期 (YYYY/MM/DD)

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -8,6 +8,15 @@ export const statusMap = {
   5: "自动+人工检测为东方"
 };
 
+// 东方状态选项（管理后台用）
+export const touhouStatusOptions = [
+  { value: 0, label: "未检测",    cssClass: "status-unknown" },
+  { value: 1, label: "自动东方",  cssClass: "status-touhou" },
+  { value: 2, label: "自动非东方", cssClass: "status-non-touhou" },
+  { value: 3, label: "人工东方",  cssClass: "status-touhou" },
+  { value: 4, label: "人工非东方", cssClass: "status-non-touhou" },
+];
+
 // 格式化日期 (YYYY/MM/DD)
 export const formatDate = (timestamp, locale = "zh-CN") => {
   if (!timestamp) return '未知日期'

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -68,10 +68,11 @@ const toast = ref('')
 const savingBvid = ref(null)
 
 const statusLabelMap = Object.fromEntries(touhouStatusOptions.map(o => [o.value, o.label]))
-const statusClassMap = Object.fromEntries(touhouStatusOptions.map(o => [o.value, o.cssClass]))
+
+const STATUS_CSS = { 1: 'status-touhou', 2: 'status-non-touhou', 3: 'status-touhou', 4: 'status-non-touhou' }
 
 function statusClass(s) {
-  return statusClassMap[s] || 'status-unknown'
+  return STATUS_CSS[s] || 'status-unknown'
 }
 
 function getVideoUrl(bvid) {

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -9,6 +9,7 @@
     </header>
     <main class="dashboard-content">
       <h3>视频管理</h3>
+      <p v-if="toast" class="toast" :class="toast.type">{{ toast.text }}</p>
       <p v-if="loading" class="status">加载中...</p>
       <p v-else-if="error" class="status error">{{ error }}</p>
       <p v-else-if="!videos.length" class="status">暂无视频数据</p>
@@ -29,7 +30,7 @@
             <td class="col-uploader">{{ v.uploader_name }}</td>
             <td class="col-status">
               <span :class="['status-tag', statusClass(v.touhou_status)]">
-                {{ statusLabelMap[v.touhou_status] }}
+                {{ statusLabelMap[v.touhou_status] || '未知状态' }}
               </span>
             </td>
             <td class="col-action">
@@ -63,6 +64,7 @@ const { state, isLoggedIn, logout } = useAuth()
 const videos = ref([])
 const loading = ref(true)
 const error = ref('')
+const toast = ref('')
 const savingBvid = ref(null)
 
 const statusLabelMap = Object.fromEntries(touhouStatusOptions.map(o => [o.value, o.label]))
@@ -76,13 +78,18 @@ function getVideoUrl(bvid) {
   return `https://www.bilibili.com/video/${bvid}`
 }
 
+function showToast(text, type = 'success') {
+  toast.value = { text, type }
+  setTimeout(() => { toast.value = '' }, 3000)
+}
+
 async function loadVideos() {
   loading.value = true
   error.value = ''
   try {
     videos.value = await apiGet('/videos')
   } catch (e) {
-    error.value = e?.message || String(e) || '加载失败'
+    error.value = e instanceof Error && e.message ? e.message : '加载失败'
   } finally {
     loading.value = false
   }
@@ -90,13 +97,14 @@ async function loadVideos() {
 
 async function handleStatusChange(video, newStatus) {
   const val = parseInt(newStatus, 10)
-  if (isNaN(val)) return
+  if (isNaN(val) || val === video.touhou_status) return
   savingBvid.value = video.bvid
   try {
     await apiPatch(`/admin/videos/${video.bvid}/touhou-status`, { touhou_status: val })
     video.touhou_status = val
+    showToast(`已将 ${video.bvid} 状态改为 ${statusLabelMap[val] || val}`)
   } catch (e) {
-    alert(`修改失败: ${e.message || '未知错误'}`)
+    showToast(`修改失败: ${e instanceof Error ? e.message : '未知错误'}`, 'error')
   } finally {
     savingBvid.value = null
   }
@@ -253,5 +261,22 @@ onMounted(loadVideos)
 .status-unknown {
   background: #f5f5f5;
   color: #999;
+}
+
+.toast {
+  padding: 0.6rem 1rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  margin: 0 0 1rem;
+}
+
+.toast.success {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.toast.error {
+  background: #fce4ec;
+  color: #c62828;
 }
 </style>

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -8,29 +8,117 @@
       </div>
     </header>
     <main class="dashboard-content">
-      <p>欢迎使用 Touhou Memory Archive 管理后台。</p>
-      <p>后续功能开发中...</p>
+      <h3>视频管理</h3>
+      <p v-if="loading" class="status">加载中...</p>
+      <p v-else-if="error" class="status error">{{ error }}</p>
+      <p v-else-if="!videos.length" class="status">暂无视频数据</p>
+      <table v-else class="video-table">
+        <thead>
+          <tr>
+            <th class="col-title">标题</th>
+            <th class="col-uploader">UP主</th>
+            <th class="col-status">东方状态</th>
+            <th class="col-action">操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="v in videos" :key="v.bvid">
+            <td class="col-title">
+              <a :href="getVideoUrl(v.bvid)" target="_blank" rel="noopener">{{ v.title }}</a>
+            </td>
+            <td class="col-uploader">{{ v.uploader_name }}</td>
+            <td class="col-status">
+              <span :class="['status-tag', statusClass(v.touhou_status)]">
+                {{ statusMap[v.touhou_status] }}
+              </span>
+            </td>
+            <td class="col-action">
+              <select
+                :value="v.touhou_status"
+                :disabled="savingBvid === v.bvid"
+                @change="handleStatusChange(v, $event.target.value)"
+              >
+                <option :value="0">未检测</option>
+                <option :value="1">自动东方</option>
+                <option :value="2">自动非东方</option>
+                <option :value="3">人工东方</option>
+                <option :value="4">人工非东方</option>
+              </select>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </main>
   </div>
 </template>
 
 <script setup>
-import { watch } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuth } from '../../composables/useAuth.js'
+import { apiGet, apiPatch } from '../../api/client.js'
 
 const router = useRouter()
 const { state, isLoggedIn, logout } = useAuth()
+
+const videos = ref([])
+const loading = ref(true)
+const error = ref('')
+const savingBvid = ref(null)
+
+const statusMap = {
+  0: '未检测',
+  1: '自动东方',
+  2: '自动非东方',
+  3: '人工东方',
+  4: '人工非东方',
+}
+
+function statusClass(s) {
+  if (s === 1 || s === 3) return 'status-touhou'
+  if (s === 2 || s === 4) return 'status-non-touhou'
+  return 'status-unknown'
+}
+
+function getVideoUrl(bvid) {
+  return `https://www.bilibili.com/video/${bvid}`
+}
+
+async function loadVideos() {
+  loading.value = true
+  error.value = ''
+  try {
+    videos.value = await apiGet('/videos')
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleStatusChange(video, newStatus) {
+  const val = parseInt(newStatus)
+  savingBvid.value = video.bvid
+  try {
+    await apiPatch(`/admin/videos/${video.bvid}/touhou-status`, { touhou_status: val })
+    video.touhou_status = val
+  } catch (e) {
+    alert(`修改失败: ${e.message}`)
+  } finally {
+    savingBvid.value = null
+  }
+}
 
 function handleLogout() {
   logout()
   router.push({ name: 'admin-login' })
 }
 
-// token 过期后 fetchUser 清除了状态，跳转登录页
 watch(isLoggedIn, (val) => {
   if (!val) router.push({ name: 'admin-login' })
 })
+
+onMounted(loadVideos)
 </script>
 
 <style scoped>
@@ -77,6 +165,100 @@ watch(isLoggedIn, (val) => {
 
 .dashboard-content {
   padding: 2rem;
+}
+
+.dashboard-content h3 {
+  margin: 0 0 1rem;
+  color: #333;
+}
+
+.status {
   color: #666;
+  text-align: center;
+  padding: 2rem;
+}
+
+.status.error {
+  color: #e74c3c;
+}
+
+.video-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+.video-table th,
+.video-table td {
+  padding: 0.6rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #eee;
+  font-size: 0.875rem;
+}
+
+.video-table th {
+  background: #fafafa;
+  color: #555;
+  font-weight: 600;
+}
+
+.video-table a {
+  color: #fb7299;
+  text-decoration: none;
+}
+
+.video-table a:hover {
+  text-decoration: underline;
+}
+
+.col-title {
+  max-width: 400px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.col-uploader {
+  width: 120px;
+}
+
+.col-status {
+  width: 100px;
+}
+
+.col-action {
+  width: 140px;
+}
+
+.col-action select {
+  padding: 0.3rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.status-tag {
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+}
+
+.status-touhou {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.status-non-touhou {
+  background: #fce4ec;
+  color: #c62828;
+}
+
+.status-unknown {
+  background: #f5f5f5;
+  color: #999;
 }
 </style>

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -97,13 +97,14 @@ async function loadVideos() {
 }
 
 async function handleStatusChange(video, newStatus) {
-  const val = parseInt(newStatus)
+  const val = parseInt(newStatus, 10)
+  if (isNaN(val)) return
   savingBvid.value = video.bvid
   try {
     await apiPatch(`/admin/videos/${video.bvid}/touhou-status`, { touhou_status: val })
     video.touhou_status = val
   } catch (e) {
-    alert(`修改失败: ${e.message}`)
+    alert(`修改失败: ${e.message || '未知错误'}`)
   } finally {
     savingBvid.value = null
   }

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -64,7 +64,8 @@ const { state, isLoggedIn, logout } = useAuth()
 const videos = ref([])
 const loading = ref(true)
 const error = ref('')
-const toast = ref('')
+const toast = ref(null)
+let toastTimer = null
 const savingBvid = ref(null)
 
 const statusLabelMap = Object.fromEntries(touhouStatusOptions.map(o => [o.value, o.label]))
@@ -80,8 +81,9 @@ function getVideoUrl(bvid) {
 }
 
 function showToast(text, type = 'success') {
+  if (toastTimer) clearTimeout(toastTimer)
   toast.value = { text, type }
-  setTimeout(() => { toast.value = '' }, 3000)
+  toastTimer = setTimeout(() => { toast.value = null }, 3000)
 }
 
 async function loadVideos() {

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -69,11 +69,13 @@ let toastTimer = null
 const savingBvid = ref(null)
 
 const statusLabelMap = Object.fromEntries(touhouStatusOptions.map(o => [o.value, o.label]))
-
-const STATUS_CSS = { 1: 'status-touhou', 2: 'status-non-touhou', 3: 'status-touhou', 4: 'status-non-touhou' }
+const statusCssMap = Object.fromEntries(touhouStatusOptions.map(o => [
+  o.value,
+  o.touhou === true ? 'status-touhou' : o.touhou === false ? 'status-non-touhou' : 'status-unknown',
+]))
 
 function statusClass(s) {
-  return STATUS_CSS[s] || 'status-unknown'
+  return statusCssMap[s] || 'status-unknown'
 }
 
 function getVideoUrl(bvid) {

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -29,7 +29,7 @@
             <td class="col-uploader">{{ v.uploader_name }}</td>
             <td class="col-status">
               <span :class="['status-tag', statusClass(v.touhou_status)]">
-                {{ statusMap[v.touhou_status] }}
+                {{ statusLabelMap[v.touhou_status] }}
               </span>
             </td>
             <td class="col-action">
@@ -38,11 +38,9 @@
                 :disabled="savingBvid === v.bvid"
                 @change="handleStatusChange(v, $event.target.value)"
               >
-                <option :value="0">未检测</option>
-                <option :value="1">自动东方</option>
-                <option :value="2">自动非东方</option>
-                <option :value="3">人工东方</option>
-                <option :value="4">人工非东方</option>
+                <option v-for="opt in touhouStatusOptions" :key="opt.value" :value="opt.value">
+                  {{ opt.label }}
+                </option>
               </select>
             </td>
           </tr>
@@ -57,6 +55,7 @@ import { ref, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuth } from '../../composables/useAuth.js'
 import { apiGet, apiPatch } from '../../api/client.js'
+import { touhouStatusOptions } from '../../utils/index.js'
 
 const router = useRouter()
 const { state, isLoggedIn, logout } = useAuth()
@@ -66,18 +65,11 @@ const loading = ref(true)
 const error = ref('')
 const savingBvid = ref(null)
 
-const statusMap = {
-  0: '未检测',
-  1: '自动东方',
-  2: '自动非东方',
-  3: '人工东方',
-  4: '人工非东方',
-}
+const statusLabelMap = Object.fromEntries(touhouStatusOptions.map(o => [o.value, o.label]))
+const statusClassMap = Object.fromEntries(touhouStatusOptions.map(o => [o.value, o.cssClass]))
 
 function statusClass(s) {
-  if (s === 1 || s === 3) return 'status-touhou'
-  if (s === 2 || s === 4) return 'status-non-touhou'
-  return 'status-unknown'
+  return statusClassMap[s] || 'status-unknown'
 }
 
 function getVideoUrl(bvid) {
@@ -90,7 +82,7 @@ async function loadVideos() {
   try {
     videos.value = await apiGet('/videos')
   } catch (e) {
-    error.value = e.message
+    error.value = e?.message || String(e) || '加载失败'
   } finally {
     loading.value = false
   }

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -37,7 +37,7 @@
               <select
                 :value="v.touhou_status"
                 :disabled="savingBvid === v.bvid"
-                @change="handleStatusChange(v, $event.target.value)"
+                @change="handleStatusChange(v, $event)"
               >
                 <option v-for="opt in touhouStatusOptions" :key="opt.value" :value="opt.value">
                   {{ opt.label }}
@@ -52,7 +52,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted, onUnmounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuth } from '../../composables/useAuth.js'
 import { apiGet, apiPatch } from '../../api/client.js'
@@ -98,8 +98,8 @@ async function loadVideos() {
   }
 }
 
-async function handleStatusChange(video, newStatus) {
-  const val = parseInt(newStatus, 10)
+async function handleStatusChange(video, event) {
+  const val = parseInt(event.target.value, 10)
   if (isNaN(val) || val === video.touhou_status) return
   savingBvid.value = video.bvid
   try {
@@ -107,6 +107,7 @@ async function handleStatusChange(video, newStatus) {
     video.touhou_status = val
     showToast(`已将 ${video.bvid} 状态改为 ${statusLabelMap[val] || val}`)
   } catch (e) {
+    event.target.value = video.touhou_status
     showToast(`修改失败: ${e instanceof Error ? e.message : '未知错误'}`, 'error')
   } finally {
     savingBvid.value = null
@@ -123,6 +124,7 @@ watch(isLoggedIn, (val) => {
 })
 
 onMounted(loadVideos)
+onUnmounted(() => { if (toastTimer) clearTimeout(toastTimer) })
 </script>
 
 <style scoped>


### PR DESCRIPTION
后端：
- 新增 PATCH /api/v1/admin/videos/{bvid}/touhou-status
- admin+ 角色可修改，校验合法值 0-4

前端：
- DashboardView 显示视频列表（标题、UP主、东方状态）
- 下拉选择修改状态，实时保存
- 状态标签颜色区分（东方绿、非东方红）

## 来自 Sourcery 的摘要

添加管理员 API 和仪表盘界面，用于查看视频并编辑它们的 Touhou 状态。

新功能：
- 引入一个管理员 PATCH 接口，用于在验证允许值的前提下更新视频的 Touhou 状态。
- 在管理员仪表盘中显示视频表格，包括标题、上传者和 Touhou 状态，并提供直达 B 站的链接。
- 允许管理员在仪表盘中通过下拉菜单更改 Touhou 状态，并实时保存修改。

增强：
- 为管理员仪表盘添加样式，包括视频管理表格、以 Touhou/非 Touhou 颜色区分的状态标签，以及改进的加载/错误/空状态显示。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在管理面板和受保护的 API 端点中添加用于查看视频并编辑其东方 Project 状态的管理功能。

新功能：
- 暴露一个管理员 PATCH 端点，用于在验证状态值后更新视频的东方状态。
- 添加一个管理员仪表盘视频表格，显示标题、上传者、东方状态标签以及指向 Bilibili 视频的链接。
- 允许管理员在仪表盘中通过下拉菜单更改视频的东方状态，并立即持久化保存。

增强内容：
- 为管理员仪表盘的视频管理表格添加样式，包括带颜色的状态标签、自适应列，以及基于 toast 的成功/错误反馈。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

</details>

新特性：
- 暴露一个管理员专用的 `PATCH` 端点，用于在验证状态值后更新视频的东方状态。
- 在管理面板中显示一个视频列表表格，展示标题、上传者、东方状态以及指向 B 站视频的链接。
- 允许管理员在管理面板中通过下拉菜单更改视频的东方状态，并立即持久化这些更改。

增强内容：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签，以及改进的加载中、错误和空状态展示。
- 将供管理员使用的东方状态选项集中到前端共享工具中进行统一管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

</details>

</details>

</details>

新功能：
- 暴露一个管理员 PATCH 接口，用于以经过验证的值更新视频的 Touhou 状态。
- 在管理员控制台中显示视频管理表格，包括标题、上传者、Touhou 状态以及指向 B 站视频的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并在选择后立即保存更改。

增强：
- 为管理员控制台中的视频表格添加样式，包括带颜色的状态标签、自适应列，以及基础的加载/错误/空状态显示。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在管理面板和受保护的 API 端点中添加用于查看视频并编辑其东方 Project 状态的管理功能。

新功能：
- 暴露一个管理员 PATCH 端点，用于在验证状态值后更新视频的东方状态。
- 添加一个管理员仪表盘视频表格，显示标题、上传者、东方状态标签以及指向 Bilibili 视频的链接。
- 允许管理员在仪表盘中通过下拉菜单更改视频的东方状态，并立即持久化保存。

增强内容：
- 为管理员仪表盘的视频管理表格添加样式，包括带颜色的状态标签、自适应列，以及基于 toast 的成功/错误反馈。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

</details>

新特性：
- 暴露一个管理员专用的 `PATCH` 端点，用于在验证状态值后更新视频的东方状态。
- 在管理面板中显示一个视频列表表格，展示标题、上传者、东方状态以及指向 B 站视频的链接。
- 允许管理员在管理面板中通过下拉菜单更改视频的东方状态，并立即持久化这些更改。

增强内容：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签，以及改进的加载中、错误和空状态展示。
- 将供管理员使用的东方状态选项集中到前端共享工具中进行统一管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

</details>

</details>

</details>

</details>

新功能：
- 引入一个管理员 PATCH 端点，用于更新视频的 Touhou 状态，并对允许的状态值进行校验。
- 在管理员仪表板中显示一个视频表格，包括标题、上传者、Touhou 状态标签以及指向视频的直接链接。
- 允许管理员在仪表板中通过下拉菜单更改视频的 Touhou 状态，并立即保存更改。

改进：
- 为管理员仪表板设计视频管理表格样式，包含 Touhou/非 Touhou 状态的彩色状态标签，以及基础的加载/错误/空状态显示。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在管理面板和受保护的 API 端点中添加用于查看视频并编辑其东方 Project 状态的管理功能。

新功能：
- 暴露一个管理员 PATCH 端点，用于在验证状态值后更新视频的东方状态。
- 添加一个管理员仪表盘视频表格，显示标题、上传者、东方状态标签以及指向 Bilibili 视频的链接。
- 允许管理员在仪表盘中通过下拉菜单更改视频的东方状态，并立即持久化保存。

增强内容：
- 为管理员仪表盘的视频管理表格添加样式，包括带颜色的状态标签、自适应列，以及基于 toast 的成功/错误反馈。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

</details>

新特性：
- 暴露一个管理员专用的 `PATCH` 端点，用于在验证状态值后更新视频的东方状态。
- 在管理面板中显示一个视频列表表格，展示标题、上传者、东方状态以及指向 B 站视频的链接。
- 允许管理员在管理面板中通过下拉菜单更改视频的东方状态，并立即持久化这些更改。

增强内容：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签，以及改进的加载中、错误和空状态展示。
- 将供管理员使用的东方状态选项集中到前端共享工具中进行统一管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

</details>

</details>

</details>

新功能：
- 暴露一个管理员 PATCH 接口，用于以经过验证的值更新视频的 Touhou 状态。
- 在管理员控制台中显示视频管理表格，包括标题、上传者、Touhou 状态以及指向 B 站视频的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并在选择后立即保存更改。

增强：
- 为管理员控制台中的视频表格添加样式，包括带颜色的状态标签、自适应列，以及基础的加载/错误/空状态显示。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在管理面板和受保护的 API 端点中添加用于查看视频并编辑其东方 Project 状态的管理功能。

新功能：
- 暴露一个管理员 PATCH 端点，用于在验证状态值后更新视频的东方状态。
- 添加一个管理员仪表盘视频表格，显示标题、上传者、东方状态标签以及指向 Bilibili 视频的链接。
- 允许管理员在仪表盘中通过下拉菜单更改视频的东方状态，并立即持久化保存。

增强内容：
- 为管理员仪表盘的视频管理表格添加样式，包括带颜色的状态标签、自适应列，以及基于 toast 的成功/错误反馈。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

</details>

新特性：
- 暴露一个管理员专用的 `PATCH` 端点，用于在验证状态值后更新视频的东方状态。
- 在管理面板中显示一个视频列表表格，展示标题、上传者、东方状态以及指向 B 站视频的链接。
- 允许管理员在管理面板中通过下拉菜单更改视频的东方状态，并立即持久化这些更改。

增强内容：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签，以及改进的加载中、错误和空状态展示。
- 将供管理员使用的东方状态选项集中到前端共享工具中进行统一管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过受保护的 API 和后台控制台中的表格，新增管理员功能以查看视频并编辑其 Touhou 状态。

新功能：
- 暴露一个管理员 PATCH 接口，用于使用经过验证的枚举值更新视频的 Touhou 状态。
- 在管理员控制台中显示一个视频管理表格，展示标题、上传者、Touhou 状态以及直达 Bilibili 的链接。
- 允许管理员在控制台中通过下拉菜单更改视频的 Touhou 状态，并立即持久化保存。

功能增强：
- 为管理员视频管理表格添加样式，包括带颜色的状态标签、基础的加载/错误/空状态，以及基于 toast 的成功/错误反馈。
- 在前端共享工具中集中管理 Touhou 状态选项，以便在整个管理界面中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add admin functionality to view videos and edit their Touhou status via a protected API and dashboard table.

New Features:
- Expose an admin PATCH endpoint to update a video's Touhou status with validated enum values.
- Display a video management table in the admin dashboard showing title, uploader, Touhou status, and a direct Bilibili link.
- Allow admins to change a video's Touhou status from the dashboard via a dropdown with immediate persistence.

Enhancements:
- Style the admin video management table with colored status tags, basic loading/error/empty states, and toast-based success/error feedback.
- Centralize Touhou status options in a shared frontend utility for consistent use across the admin UI.

</details>

</details>

</details>

</details>

</details>

</details>

</details>