### PR TITLE
feat: 用户管理 CRUD API 和前端页面

### DIFF
--- a/backend/src/app/api/admin.py
+++ b/backend/src/app/api/admin.py
@@ -116,6 +116,26 @@ def update_user(
     if admin.id == current.id:
         raise HTTPException(status_code=400, detail="不能修改自己的账号")
 
+    # 检查是否会移除系统中最后一个激活的 superadmin
+    will_lose_superadmin = (
+        admin.role == AdminRole.SUPERADMIN
+        and admin.is_active
+        and (
+            (body.role is not None and body.role != AdminRole.SUPERADMIN)
+            or (body.is_active is not None and not body.is_active)
+        )
+    )
+    if will_lose_superadmin:
+        other_superadmins = session.exec(
+            select(Admin).where(
+                Admin.id != admin.id,
+                Admin.role == AdminRole.SUPERADMIN,
+                Admin.is_active == True,
+            )
+        ).first()
+        if not other_superadmins:
+            raise HTTPException(status_code=409, detail="不能降级/禁用最后一个激活的超级管理员")
+
     if body.role is not None:
         admin.role = body.role
     if body.is_active is not None:
@@ -141,6 +161,17 @@ def delete_user(
         raise HTTPException(status_code=404, detail=f"用户 {user_id} 不存在")
     if admin.id == current.id:
         raise HTTPException(status_code=400, detail="不能删除自己")
+
+    if admin.role == AdminRole.SUPERADMIN and admin.is_active:
+        other_superadmins = session.exec(
+            select(Admin).where(
+                Admin.id != admin.id,
+                Admin.role == AdminRole.SUPERADMIN,
+                Admin.is_active == True,
+            )
+        ).first()
+        if not other_superadmins:
+            raise HTTPException(status_code=409, detail="不能删除最后一个激活的超级管理员")
 
     session.delete(admin)
     session.commit()

--- a/backend/src/app/api/admin.py
+++ b/backend/src/app/api/admin.py
@@ -1,11 +1,12 @@
 import logging
+import time
 from enum import IntEnum
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlmodel import Session, select
 
-from app.auth import require_role
+from app.auth import require_role, hash_password
 from domain.database import get_session
 from domain.models.admin import Admin, AdminRole
 from domain.models.video import Video
@@ -47,3 +48,100 @@ def update_touhou_status(
 
     logger.info(f"管理员 {current_admin.username} 将 {bvid} 的 touhou_status 改为 {body.touhou_status}")
     return {"bvid": bvid, "touhou_status": video.touhou_status}
+
+
+# --- 用户管理 (superadmin) ---
+
+class AdminUserOut(BaseModel):
+    id: int
+    username: str
+    role: AdminRole
+    is_active: bool
+    created_at: int
+
+
+class AdminUserCreate(BaseModel):
+    username: str = Field(min_length=2, max_length=32)
+    password: str = Field(min_length=6, max_length=128)
+    role: AdminRole = AdminRole.ADMIN
+
+
+class AdminUserUpdate(BaseModel):
+    role: AdminRole | None = None
+    is_active: bool | None = None
+    password: str | None = Field(default=None, min_length=6, max_length=128)
+
+
+@router.get("/users", response_model=list[AdminUserOut])
+def list_users(
+    session: Session = Depends(get_session),
+    _current: Admin = Depends(require_role(AdminRole.SUPERADMIN)),
+):
+    return session.exec(select(Admin).order_by(Admin.id)).all()
+
+
+@router.post("/users", response_model=AdminUserOut, status_code=201)
+def create_user(
+    body: AdminUserCreate,
+    session: Session = Depends(get_session),
+    current: Admin = Depends(require_role(AdminRole.SUPERADMIN)),
+):
+    existing = session.exec(select(Admin).where(Admin.username == body.username)).first()
+    if existing:
+        raise HTTPException(status_code=409, detail=f"用户名 {body.username} 已存在")
+
+    admin = Admin(
+        username=body.username,
+        hashed_password=hash_password(body.password),
+        role=body.role,
+        created_at=int(time.time()),
+    )
+    session.add(admin)
+    session.commit()
+    session.refresh(admin)
+    logger.info(f"管理员 {current.username} 创建了用户 {admin.username} (role={admin.role})")
+    return admin
+
+
+@router.patch("/users/{user_id}", response_model=AdminUserOut)
+def update_user(
+    user_id: int,
+    body: AdminUserUpdate,
+    session: Session = Depends(get_session),
+    current: Admin = Depends(require_role(AdminRole.SUPERADMIN)),
+):
+    admin = session.get(Admin, user_id)
+    if not admin:
+        raise HTTPException(status_code=404, detail=f"用户 {user_id} 不存在")
+    if admin.id == current.id:
+        raise HTTPException(status_code=400, detail="不能修改自己的账号")
+
+    if body.role is not None:
+        admin.role = body.role
+    if body.is_active is not None:
+        admin.is_active = body.is_active
+    if body.password is not None:
+        admin.hashed_password = hash_password(body.password)
+
+    session.add(admin)
+    session.commit()
+    session.refresh(admin)
+    logger.info(f"管理员 {current.username} 修改了用户 {admin.username}")
+    return admin
+
+
+@router.delete("/users/{user_id}", status_code=204)
+def delete_user(
+    user_id: int,
+    session: Session = Depends(get_session),
+    current: Admin = Depends(require_role(AdminRole.SUPERADMIN)),
+):
+    admin = session.get(Admin, user_id)
+    if not admin:
+        raise HTTPException(status_code=404, detail=f"用户 {user_id} 不存在")
+    if admin.id == current.id:
+        raise HTTPException(status_code=400, detail="不能删除自己")
+
+    session.delete(admin)
+    session.commit()
+    logger.info(f"管理员 {current.username} 删除了用户 {admin.username}")

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -74,6 +74,6 @@ export function apiPatch<T = unknown>(path: string, body?: unknown): Promise<T> 
   return request<T>('PATCH', path, { body })
 }
 
-export function apiDelete<T = unknown>(path: string): Promise<T> {
-  return request<T>('DELETE', path)
+export function apiDelete(path: string): Promise<void> {
+  return request<void>('DELETE', path)
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -73,3 +73,7 @@ export function apiPostForm<T = unknown>(path: string, formData: URLSearchParams
 export function apiPatch<T = unknown>(path: string, body?: unknown): Promise<T> {
   return request<T>('PATCH', path, { body })
 }
+
+export function apiDelete<T = unknown>(path: string): Promise<T> {
+  return request<T>('DELETE', path)
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from 'vue'
 import PrimeVue from 'primevue/config'
 import Aura from '@primevue/themes/aura'
 import ToastService from 'primevue/toastservice'
+import ConfirmationService from 'primevue/confirmationservice'
 import 'primeicons/primeicons.css'
 
 import './style.css'
@@ -21,6 +22,7 @@ app.use(PrimeVue, {
   }
 })
 app.use(ToastService)
+app.use(ConfirmationService)
 app.use(router)
 
 app.mount('#app')

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -6,6 +6,7 @@ const LoginView = () => import('../views/admin/LoginView.vue')
 const AdminLayout = () => import('../views/admin/AdminLayout.vue')
 const DashboardHome = () => import('../views/admin/DashboardHome.vue')
 const VideoManage = () => import('../views/admin/VideoManage.vue')
+const UserManage = () => import('../views/admin/UserManage.vue')
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -34,6 +35,11 @@ const router = createRouter({
           path: 'videos',
           name: 'admin-videos',
           component: VideoManage
+        },
+        {
+          path: 'users',
+          name: 'admin-users',
+          component: UserManage
         }
       ]
     }

--- a/frontend/src/views/admin/AdminLayout.vue
+++ b/frontend/src/views/admin/AdminLayout.vue
@@ -14,6 +14,10 @@
           <i class="pi pi-video" />
           <span>视频管理</span>
         </router-link>
+        <router-link :to="{ name: 'admin-users' }" class="nav-item" active-class="active">
+          <i class="pi pi-users" />
+          <span>用户管理</span>
+        </router-link>
       </nav>
     </aside>
 

--- a/frontend/src/views/admin/UserManage.vue
+++ b/frontend/src/views/admin/UserManage.vue
@@ -1,0 +1,216 @@
+<template>
+  <div class="user-manage">
+    <div class="header">
+      <h3>用户管理</h3>
+      <Button label="添加用户" icon="pi pi-plus" @click="showCreate = true" />
+    </div>
+    <Toast />
+
+    <DataTable :value="users" :loading="loading" stripedRows emptyMessage="暂无用户">
+      <Column field="id" header="ID" style="width: 60px" />
+      <Column field="username" header="用户名" />
+      <Column field="role" header="角色" style="width: 120px">
+        <template #body="{ data }">
+          <Tag :value="roleLabel(data.role)" :severity="data.role === 1 ? 'success' : 'info'" />
+        </template>
+      </Column>
+      <Column field="is_active" header="状态" style="width: 100px">
+        <template #body="{ data }">
+          <Tag :value="data.is_active ? '启用' : '禁用'" :severity="data.is_active ? 'success' : 'danger'" />
+        </template>
+      </Column>
+      <Column header="操作" style="width: 200px">
+        <template #body="{ data }">
+          <Button icon="pi pi-pencil" text size="small" @click="startEdit(data)" />
+          <Button
+            :icon="data.is_active ? 'pi pi-ban' : 'pi pi-check'"
+            text
+            size="small"
+            :severity="data.is_active ? 'danger' : 'success'"
+            @click="toggleActive(data)"
+          />
+          <Button icon="pi pi-trash" text size="small" severity="danger" @click="confirmDelete(data)" />
+        </template>
+      </Column>
+    </DataTable>
+
+    <!-- 创建用户对话框 -->
+    <Dialog v-model:visible="showCreate" modal header="添加用户" :style="{ width: '360px' }">
+      <div class="form-grid">
+        <label>用户名</label>
+        <InputText v-model="form.username" fluid />
+        <label>密码</label>
+        <Password v-model="form.password" :feedback="false" toggleMask fluid />
+        <label>角色</label>
+        <Select v-model="form.role" :options="roleOptions" optionLabel="label" optionValue="value" fluid />
+      </div>
+      <template #footer>
+        <Button label="取消" severity="secondary" text @click="showCreate = false" />
+        <Button label="创建" :loading="saving" @click="handleCreate" />
+      </template>
+    </Dialog>
+
+    <!-- 编辑用户对话框 -->
+    <Dialog v-model:visible="showEdit" modal header="编辑用户" :style="{ width: '360px' }">
+      <div class="form-grid">
+        <label>用户名</label>
+        <InputText :modelValue="editingUser?.username" disabled fluid />
+        <label>角色</label>
+        <Select v-model="editForm.role" :options="roleOptions" optionLabel="label" optionValue="value" fluid />
+        <label>新密码（留空不修改）</label>
+        <Password v-model="editForm.password" :feedback="false" toggleMask fluid />
+      </div>
+      <template #footer>
+        <Button label="取消" severity="secondary" text @click="showEdit = false" />
+        <Button label="保存" :loading="saving" @click="handleEdit" />
+      </template>
+    </Dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useToast } from 'primevue/usetoast'
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import Button from 'primevue/button'
+import Tag from 'primevue/tag'
+import Dialog from 'primevue/dialog'
+import InputText from 'primevue/inputtext'
+import Password from 'primevue/password'
+import Select from 'primevue/select'
+import Toast from 'primevue/toast'
+import { apiGet, apiPost, apiPatch, apiDelete } from '../../api/client'
+
+interface AdminUser {
+  id: number
+  username: string
+  role: number
+  is_active: boolean
+  created_at: number
+}
+
+const toast = useToast()
+const users = ref<AdminUser[]>([])
+const loading = ref(true)
+const saving = ref(false)
+
+const showCreate = ref(false)
+const showEdit = ref(false)
+const editingUser = ref<AdminUser | null>(null)
+
+const form = ref({ username: '', password: '', role: 2 })
+const editForm = ref({ role: 2, password: '' })
+
+const roleOptions = [
+  { label: '超级管理员', value: 1 },
+  { label: '管理员', value: 2 },
+]
+
+function roleLabel(role: number) {
+  return role === 1 ? '超级管理员' : '管理员'
+}
+
+async function loadUsers() {
+  loading.value = true
+  try {
+    users.value = await apiGet<AdminUser[]>('/admin/users')
+  } catch (e) {
+    toast.add({ severity: 'error', summary: '加载失败', detail: e instanceof Error ? e.message : '未知错误', life: 5000 })
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleCreate() {
+  saving.value = true
+  try {
+    await apiPost('/admin/users', form.value)
+    toast.add({ severity: 'success', summary: '创建成功', life: 3000 })
+    showCreate.value = false
+    form.value = { username: '', password: '', role: 2 }
+    await loadUsers()
+  } catch (e) {
+    toast.add({ severity: 'error', summary: '创建失败', detail: e instanceof Error ? e.message : '未知错误', life: 5000 })
+  } finally {
+    saving.value = false
+  }
+}
+
+function startEdit(user: AdminUser) {
+  editingUser.value = user
+  editForm.value = { role: user.role, password: '' }
+  showEdit.value = true
+}
+
+async function handleEdit() {
+  if (!editingUser.value) return
+  saving.value = true
+  try {
+    const body: { role?: number; password?: string } = { role: editForm.value.role }
+    if (editForm.value.password) body.password = editForm.value.password
+    await apiPatch(`/admin/users/${editingUser.value.id}`, body)
+    toast.add({ severity: 'success', summary: '修改成功', life: 3000 })
+    showEdit.value = false
+    await loadUsers()
+  } catch (e) {
+    toast.add({ severity: 'error', summary: '修改失败', detail: e instanceof Error ? e.message : '未知错误', life: 5000 })
+  } finally {
+    saving.value = false
+  }
+}
+
+async function toggleActive(user: AdminUser) {
+  try {
+    await apiPatch(`/admin/users/${user.id}`, { is_active: !user.is_active })
+    toast.add({ severity: 'success', summary: user.is_active ? '已禁用' : '已启用', life: 3000 })
+    await loadUsers()
+  } catch (e) {
+    toast.add({ severity: 'error', summary: '操作失败', detail: e instanceof Error ? e.message : '未知错误', life: 5000 })
+  }
+}
+
+function confirmDelete(user: AdminUser) {
+  if (confirm(`确定要删除用户 ${user.username} 吗？`)) {
+    handleDelete(user)
+  }
+}
+
+async function handleDelete(user: AdminUser) {
+  try {
+    await apiDelete(`/admin/users/${user.id}`)
+    toast.add({ severity: 'success', summary: '已删除', life: 3000 })
+    await loadUsers()
+  } catch (e) {
+    toast.add({ severity: 'error', summary: '删除失败', detail: e instanceof Error ? e.message : '未知错误', life: 5000 })
+  }
+}
+
+onMounted(loadUsers)
+</script>
+
+<style scoped>
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.header h3 {
+  margin: 0;
+  color: var(--text-color);
+}
+
+.form-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-grid label {
+  font-size: 0.875rem;
+  color: var(--text-color-secondary);
+  margin-top: 0.5rem;
+}
+</style>

--- a/frontend/src/views/admin/UserManage.vue
+++ b/frontend/src/views/admin/UserManage.vue
@@ -5,6 +5,7 @@
       <Button label="添加用户" icon="pi pi-plus" @click="showCreate = true" />
     </div>
     <Toast />
+    <ConfirmDialog />
 
     <DataTable :value="users" :loading="loading" stripedRows emptyMessage="暂无用户">
       <Column field="id" header="ID" style="width: 60px" />
@@ -27,6 +28,7 @@
             text
             size="small"
             :severity="data.is_active ? 'danger' : 'success'"
+            :disabled="togglingId === data.id"
             @click="toggleActive(data)"
           />
           <Button icon="pi pi-trash" text size="small" severity="danger" @click="confirmDelete(data)" />
@@ -71,6 +73,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useToast } from 'primevue/usetoast'
+import { useConfirm } from 'primevue/useconfirm'
 import DataTable from 'primevue/datatable'
 import Column from 'primevue/column'
 import Button from 'primevue/button'
@@ -80,12 +83,13 @@ import InputText from 'primevue/inputtext'
 import Password from 'primevue/password'
 import Select from 'primevue/select'
 import Toast from 'primevue/toast'
+import ConfirmDialog from 'primevue/confirmdialog'
 import { apiGet, apiPost, apiPatch, apiDelete } from '../../api/client'
 
 interface AdminUser {
   id: number
   username: string
-  role: number
+  role: AdminRole
   is_active: boolean
   created_at: number
 }
@@ -97,9 +101,11 @@ enum AdminRole {
 }
 
 const toast = useToast()
+const confirm = useConfirm()
 const users = ref<AdminUser[]>([])
 const loading = ref(true)
 const saving = ref(false)
+const togglingId = ref<number | null>(null)
 
 const showCreate = ref(false)
 const showEdit = ref(false)
@@ -167,19 +173,30 @@ async function handleEdit() {
 }
 
 async function toggleActive(user: AdminUser) {
+  if (togglingId.value) return
+  togglingId.value = user.id
   try {
     await apiPatch(`/admin/users/${user.id}`, { is_active: !user.is_active })
     toast.add({ severity: 'success', summary: user.is_active ? '已禁用' : '已启用', life: 3000 })
     await loadUsers()
   } catch (e) {
     toast.add({ severity: 'error', summary: '操作失败', detail: e instanceof Error ? e.message : '未知错误', life: 5000 })
+  } finally {
+    togglingId.value = null
   }
 }
 
 function confirmDelete(user: AdminUser) {
-  if (confirm(`确定要删除用户 ${user.username} 吗？`)) {
-    handleDelete(user)
-  }
+  confirm.require({
+    message: `确定要删除用户 ${user.username} 吗？`,
+    header: '确认删除',
+    icon: 'pi pi-exclamation-triangle',
+    rejectLabel: '取消',
+    acceptLabel: '删除',
+    rejectClass: 'p-button-secondary p-button-outlined',
+    acceptClass: 'p-button-danger',
+    accept: () => handleDelete(user),
+  })
 }
 
 async function handleDelete(user: AdminUser) {

--- a/frontend/src/views/admin/UserManage.vue
+++ b/frontend/src/views/admin/UserManage.vue
@@ -11,7 +11,7 @@
       <Column field="username" header="用户名" />
       <Column field="role" header="角色" style="width: 120px">
         <template #body="{ data }">
-          <Tag :value="roleLabel(data.role)" :severity="data.role === 1 ? 'success' : 'info'" />
+          <Tag :value="roleLabel(data.role)" :severity="data.role === AdminRole.SUPERADMIN ? 'success' : 'info'" />
         </template>
       </Column>
       <Column field="is_active" header="状态" style="width: 100px">
@@ -90,6 +90,12 @@ interface AdminUser {
   created_at: number
 }
 
+// 与后端 AdminRole IntEnum 保持一致
+enum AdminRole {
+  SUPERADMIN = 1,
+  ADMIN = 2,
+}
+
 const toast = useToast()
 const users = ref<AdminUser[]>([])
 const loading = ref(true)
@@ -99,16 +105,16 @@ const showCreate = ref(false)
 const showEdit = ref(false)
 const editingUser = ref<AdminUser | null>(null)
 
-const form = ref({ username: '', password: '', role: 2 })
-const editForm = ref({ role: 2, password: '' })
+const form = ref({ username: '', password: '', role: AdminRole.ADMIN })
+const editForm = ref({ role: AdminRole.ADMIN, password: '' })
 
 const roleOptions = [
-  { label: '超级管理员', value: 1 },
-  { label: '管理员', value: 2 },
+  { label: '超级管理员', value: AdminRole.SUPERADMIN },
+  { label: '管理员', value: AdminRole.ADMIN },
 ]
 
 function roleLabel(role: number) {
-  return role === 1 ? '超级管理员' : '管理员'
+  return role === AdminRole.SUPERADMIN ? '超级管理员' : '管理员'
 }
 
 async function loadUsers() {
@@ -128,7 +134,7 @@ async function handleCreate() {
     await apiPost('/admin/users', form.value)
     toast.add({ severity: 'success', summary: '创建成功', life: 3000 })
     showCreate.value = false
-    form.value = { username: '', password: '', role: 2 }
+    form.value = { username: '', password: '', role: AdminRole.ADMIN }
     await loadUsers()
   } catch (e) {
     toast.add({ severity: 'error', summary: '创建失败', detail: e instanceof Error ? e.message : '未知错误', life: 5000 })


### PR DESCRIPTION
实现了用户管理的后端 CRUD API，包括列出、创建、修改和删除管理员用户的功能。同时，新增了用户管理的前端页面，支持用户列表的展示及用户的创建、编辑和删除操作。

## Summary by Sourcery

添加仅限超级管理员使用的管理端用户管理 API，并在管理端前台集成对应的用户管理页面。

New Features:
- 引入用于管理管理端用户的后端 CRUD 接口，仅限超级管理员角色访问，并防止删除最后一个处于激活状态的超级管理员。
- 新增管理端 UI 页面，用于列出、创建、编辑、启用/禁用以及删除管理端用户。
- 在前端 API 客户端中提供可复用的 DELETE 辅助方法，并将新的用户管理视图接入到管理端路由和布局导航中。

Enhancements:
- 通过注册 PrimeVue 的 ConfirmationService，在前端启用全局确认对话框。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add superadmin-only admin user management APIs and integrate a corresponding user management page into the admin frontend.

New Features:
- Introduce backend CRUD endpoints for managing admin users, restricted to superadmin role and safeguarding against removal of the last active superadmin.
- Add an admin UI page for listing, creating, editing, enabling/disabling, and deleting admin users.
- Expose a reusable DELETE helper in the frontend API client and wire the new user management view into the admin router and layout navigation.

Enhancements:
- Enable global confirmation dialogs in the frontend by registering PrimeVue ConfirmationService.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加仅限超级管理员使用的管理端用户管理 API，并在管理端前台集成对应的用户管理页面。

New Features:
- 引入用于管理管理端用户的后端 CRUD 接口，仅限超级管理员角色访问，并防止删除最后一个处于激活状态的超级管理员。
- 新增管理端 UI 页面，用于列出、创建、编辑、启用/禁用以及删除管理端用户。
- 在前端 API 客户端中提供可复用的 DELETE 辅助方法，并将新的用户管理视图接入到管理端路由和布局导航中。

Enhancements:
- 通过注册 PrimeVue 的 ConfirmationService，在前端启用全局确认对话框。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add superadmin-only admin user management APIs and integrate a corresponding user management page into the admin frontend.

New Features:
- Introduce backend CRUD endpoints for managing admin users, restricted to superadmin role and safeguarding against removal of the last active superadmin.
- Add an admin UI page for listing, creating, editing, enabling/disabling, and deleting admin users.
- Expose a reusable DELETE helper in the frontend API client and wire the new user management view into the admin router and layout navigation.

Enhancements:
- Enable global confirmation dialogs in the frontend by registering PrimeVue ConfirmationService.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加仅限超级管理员使用的管理端用户管理 API，并在管理端前台集成对应的用户管理页面。

New Features:
- 引入用于管理管理端用户的后端 CRUD 接口，仅限超级管理员角色访问，并防止删除最后一个处于激活状态的超级管理员。
- 新增管理端 UI 页面，用于列出、创建、编辑、启用/禁用以及删除管理端用户。
- 在前端 API 客户端中提供可复用的 DELETE 辅助方法，并将新的用户管理视图接入到管理端路由和布局导航中。

Enhancements:
- 通过注册 PrimeVue 的 ConfirmationService，在前端启用全局确认对话框。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add superadmin-only admin user management APIs and integrate a corresponding user management page into the admin frontend.

New Features:
- Introduce backend CRUD endpoints for managing admin users, restricted to superadmin role and safeguarding against removal of the last active superadmin.
- Add an admin UI page for listing, creating, editing, enabling/disabling, and deleting admin users.
- Expose a reusable DELETE helper in the frontend API client and wire the new user management view into the admin router and layout navigation.

Enhancements:
- Enable global confirmation dialogs in the frontend by registering PrimeVue ConfirmationService.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加仅限超级管理员使用的管理端用户管理 API，并在管理端前台集成对应的用户管理页面。

New Features:
- 引入用于管理管理端用户的后端 CRUD 接口，仅限超级管理员角色访问，并防止删除最后一个处于激活状态的超级管理员。
- 新增管理端 UI 页面，用于列出、创建、编辑、启用/禁用以及删除管理端用户。
- 在前端 API 客户端中提供可复用的 DELETE 辅助方法，并将新的用户管理视图接入到管理端路由和布局导航中。

Enhancements:
- 通过注册 PrimeVue 的 ConfirmationService，在前端启用全局确认对话框。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add superadmin-only admin user management APIs and integrate a corresponding user management page into the admin frontend.

New Features:
- Introduce backend CRUD endpoints for managing admin users, restricted to superadmin role and safeguarding against removal of the last active superadmin.
- Add an admin UI page for listing, creating, editing, enabling/disabling, and deleting admin users.
- Expose a reusable DELETE helper in the frontend API client and wire the new user management view into the admin router and layout navigation.

Enhancements:
- Enable global confirmation dialogs in the frontend by registering PrimeVue ConfirmationService.

</details>

</details>

</details>